### PR TITLE
Bardic Performances

### DIFF
--- a/Equipment/Armour/Wearing/index.md
+++ b/Equipment/Armour/Wearing/index.md
@@ -26,6 +26,8 @@ If your species and class both grant proficiency in an armour category, you trea
 
 When doffing armour or when donning medium armour, if a character has help, then this time is halved. A single character doing nothing else can help two adjacent creatures. Two characters can't help each other don or remove armour pieces at the same time. The wearer must have help to don heavy armour pieces. Without help, they can only be donned hastily.
 
+Shields without the Worn property take 1 Action to don or doff. Worn shields are considered Arm armour of the same weight category for the purposes of donning/doffing.
+
 ##### Donning and Doffing Armour Suits
 
 | Category & Piece | Don | Don Hastily | Remove |
@@ -37,13 +39,8 @@ When doffing armour or when donning medium armour, if a character has help, then
 | Medium arm | 1 minute | 2 rounds | 2 rounds |
 | Medium leg | 1 minute | 3 rounds | 2 rounds |
 | Medium torso | 1 minute | 5 rounds | 3 rounds |
+| Medium Helmet | 1 action | 1 action | 1 action |
 | Heavy arm | 1 minute | 1 minute | 1 minute |
 | Heavy leg | 1 minute | 1 minute | 1 minute |
 | Heavy torso | 2 minutes | 1 minute |	2 minutes |
-
-##### Donning and Doffing Shields
-
-| Category & Piece | Don | Remove |
-|:----------------:|:---:|:------:|
-| Medium shield | 1 bonus action | 1 object interaction |
-| Heavy shield | 1 action | 1 bonus action |
+| Heavy Helmet | 1 action | 1 action | 1 action |

--- a/Equipment/Armour/Wearing/index.md
+++ b/Equipment/Armour/Wearing/index.md
@@ -26,21 +26,21 @@ If your species and class both grant proficiency in an armour category, you trea
 
 When doffing armour or when donning medium armour, if a character has help, then this time is halved. A single character doing nothing else can help two adjacent creatures. Two characters can't help each other don or remove armour pieces at the same time. The wearer must have help to don heavy armour pieces. Without help, they can only be donned hastily.
 
-Shields without the Worn property take 1 Action to don or doff. Worn shields are considered Arm armour of the same weight category for the purposes of donning/doffing.
+Shields without the Worn property take 1 Action to don or doff. Worn shields are considered arm armour of the same weight category for the purposes of donning/doffing.
 
 ##### Donning and Doffing Armour Suits
 
 | Category & Piece | Don | Don Hastily | Remove |
 |:----------------:|:---:|:-----------:|:------:|
 | Underlay | 1 minute | 5 rounds | 1 minute |
-| Light arm | 2 rounds | 1 round | 2 rounds |
-| Light leg | 3 rounds | 2 rounds | 2 rounds |
-| Light torso | 5 rounds | 2 rounds | 5 rounds |
-| Medium arm | 1 minute | 2 rounds | 2 rounds |
-| Medium leg | 1 minute | 3 rounds | 2 rounds |
-| Medium torso | 1 minute | 5 rounds | 3 rounds |
-| Medium Helmet | 1 action | 1 action | 1 action |
-| Heavy arm | 1 minute | 1 minute | 1 minute |
-| Heavy leg | 1 minute | 1 minute | 1 minute |
-| Heavy torso | 2 minutes | 1 minute |	2 minutes |
-| Heavy Helmet | 1 action | 1 action | 1 action |
+| Light Arm | 2 rounds | 1 round | 2 rounds |
+| Light Leg | 3 rounds | 2 rounds | 2 rounds |
+| Light Torso | 5 rounds | 2 rounds | 5 rounds |
+| Medium Arm | 1 minute | 2 rounds | 2 rounds |
+| Medium Helmet | 2 Actions | 1 Action | 1 Action |
+| Medium Leg | 1 minute | 3 rounds | 2 rounds |
+| Medium Torso | 1 minute | 5 rounds | 3 rounds |
+| Heavy Arm | 1 minute | 1 minute | 1 minute |
+| Heavy Helmet | 3 Actions | 2 Actions | 2 Actions |
+| Heavy Leg | 1 minute | 1 minute | 1 minute |
+| Heavy Torso | 2 minutes | 1 minute |	2 minutes |

--- a/Equipment/Armour/Wearing/index.md
+++ b/Equipment/Armour/Wearing/index.md
@@ -26,7 +26,7 @@ If your species and class both grant proficiency in an armour category, you trea
 
 When doffing armour or when donning medium armour, if a character has help, then this time is halved. A single character doing nothing else can help two adjacent creatures. Two characters can't help each other don or remove armour pieces at the same time. The wearer must have help to don heavy armour pieces. Without help, they can only be donned hastily.
 
-Shields without the Worn property take 1 Action to don or doff. Worn shields are considered arm armour of the same weight category for the purposes of donning/doffing.
+Shields without the [Worn](https://stormchaserroleplaying.com/stormchaserRPG/Equipment/Armour/Glossary/#worn) property take 1 Action to don or doff. Worn shields are considered arm armour of the same weight category for the purposes of donning/doffing.
 
 ##### Donning and Doffing Armour Suits
 

--- a/Talents/Bard/index.md
+++ b/Talents/Bard/index.md
@@ -64,6 +64,33 @@ You may reroll any ability check that you make that does not benefit from profic
 
 Once per round, you may choose a target within 60 feet that you can see. The target's next attack roll, skill check, or defence check suffers -1d. This consumes 1 use of your Bardic Inspiration. The target is immune if it can’t hear you or if it’s immune to being charmed.
 
+### Suggestion
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 15 Character Points<br>**Prerequisite:** Bardic Performance and 4 Other Bard Talents
+*Your Bardic Performance can plant the most subtle of compulsions in the minds of those who listen to you.*
+
+You can use two Actions to make a Charisma (Performance) check against a target's Wisdom defense. If successful, you speak a statement up to two sentences directing a course of action, and the target will follow it to the best of their ability. It must be worded in a way that sounds reasonable for the target. The directed action must be able to be completed within the next 8 hours. A trigger can also be given to the target as well, such as giving away all of their money if someone asks for charity. Creatures immune to the [Charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/) condition are immune to this effect.
+
+### Dirge of Doom
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 20 Character Points<br>**Prerequisite:** Suggestion and 5 Other Bard Talents
+*Your words cut deep into the hearts of the bold, exposing a gap in the armour of their courage.*
+
+When you use your Bardic Performance, you can spend 2 Actions to choose a number of targets up to your Charisma modifier within 30 feet. Make a Charisma (Performance) check against the Wisdom defense of each target. If successful, the target is [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/). Each time you use this Performance against the same target, your Charisma (Performance) check receives -1d.
+
+### Inspire Greatness
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 25 Character Points<br>**Prerequisite:** Bardic Performance and 6 Other Bard Talents
+*Through your force of will, heroes rise to deeds worthy of legend.*
+
+Choose an ally within 30 feet. They receive 2 Recovery Dice of Stamina, the larger of the two rolls as temporary Stamina, +1d to attack rolls, and +1d to Charisma defense for a number of rounds equal to your Charisma modifier. 
+
 ### Peerless Skill
 
 <div style="margin-top:-10px;"></div>
@@ -71,11 +98,56 @@ Once per round, you may choose a target within 60 feet that you can see. The tar
 #### **Cost:** 35 Character Points<br>**Prerequisite:** Jack of all Trades and 7 Other Bard Talents
 When you make a skill check, you can spend a use of your bardic inspiration die to roll with +1d. You can choose to do so after you roll the die for the skill check, but before the GM tells you whether you succeed or fail.
 
+### Soothing Performance
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 30 Character Points<br>**Prerequisite:** Bardic Performance and 8 Other Bard Talents
+*When things seem grim and your allies turn to despair, you offer a rallying cry to bolster their hearts.*
+
+You can spend 1 Action per round (up to six rounds) to give 2 Recovery Dice and remove 1 condition from a target of your choice. The condition removed must be [Dazed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Dazed/), [Frightened](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/), [Panicked](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Panicked/), [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/), or [Stunned](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Stunned/). Only one target can be affected each time you use this Performance.
+
+### Frightening Tune
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 65 Character Points<br>**Prerequisite:** Dirge of Doom and 10 Other Bard Talents
+*"Ask not for whom the bell tolls..."*
+
+Spend 2 Actions, then 1 Action per round afterward until you choose to end this Performance. All hostile targets within 30 feet of you become [Frightened]((https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/) of you until they succeed a Wisdom check against your Charisma Defense. Targets who have been affected by your Dirge of Doom Performance receive -1d to their check to end the effect. If a target moves far enough away that they cannot hear you, the effect ends until they are close enough to hear you again.
+
+### Inspire Heroics
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 40 Character Points<br>**Prerequisite:** Inspire Greatness and 11 Other Bard Talents
+*"I once saw a man thrown across the room by a rampaging golem. He stood up, wiped the blood from his mouth, and said, "I can do this all day."*
+
+Spend 3 Actions, then 1 Action per round afterward until you choose to end this Performance. A number of targets within 60 feet up to your Charisma Modifier receive +1d to all defenses every round while you maintain this Performance.
+
+### Mass Suggestion
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 80 Character Points<br>**Prerequisite:** Suggestion and 12 Other Bard Talents
+*Your sword will end my life, but my words moved your people to end your reign.*
+
+When you use your Suggestion Performance, you can now influence up to 12 targets within 60 feet who can hear you.
+
+### Deadly Performance
+
+<div style="margin-top:-10px;"></div>
+
+#### **Cost:** 50 Character Points<br>**Prerequisite:** Bardic Performance and 13 Other Bard Talents
+*When she danced, the world seemed to pause to become her audience. When she finished, all the world's gaze stayed fixed to her, dead and cold.*
+
+Spend 3 Actions. Make a Charisma (Performance) check against the Wisdom defense of a target within 30 feet that can hear and see you. On a success, the target takes 7d8+30 profane damage. On a failure, the target is Dazed for a number of rounds equal to your Charisma Modifier. Invoking this Performance calls forth hungry, angry spirits from a plane devoid of life. If a Bard uses this Performance more than once per day, they must make a DC 17 Constituion check. On a failure, the Performance acts normally, but they user also suffers the largest rolled damage die, plus their Charisma modifier, profane damage.
+
 ### Virtuoso
 
 <div style="margin-top:-10px;"></div>
 
-#### **Cost:** 100 Character Points<br>**Prerequisite:** 14 Other Bard Talents
+#### **Cost:** 50 Character Points<br>**Prerequisite:** 14 Other Bard Talents
 *You are the epitome of music and magic.*
 
 Your Dexterity and Charisma scores increase by 2. Your maximum for those scores also increases by 2. Additionally, when you roll initiative and have no uses of Bardic Inspiration left, you regain a number of uses equal to your Charisma modifier.

--- a/Talents/Bard/index.md
+++ b/Talents/Bard/index.md
@@ -35,7 +35,7 @@ Untold wonders and secrets exist for those skillful enough to discover them. Thr
 #### Bardic Inspiration
 *You can inspire others through stirring words or music.*
 
-To do so, you use a bonus action on your turn to choose one creature other than yourself within 60 feet of you who can hear you. That creature gains one Bardic Inspiration die, a d20.
+To do so, you use an action on your turn to choose one creature other than yourself within 60 feet of you who can hear you. That creature gains one Bardic Inspiration die, a d20.
 
 Once within the next 10 minutes, the creature can roll the die as an instance of advantage on one ability check, attack roll, or defence check it makes. The creature can wait until after it rolls the original die before deciding to use the Bardic Inspiration die, but must decide before the DM says whether the roll succeeds or fails. Once the Bardic Inspiration die is rolled, it is lost. A creature can have only one Bardic Inspiration die at a time.
 
@@ -71,7 +71,7 @@ Once per round, you may choose a target within 60 feet that you can see. The tar
 #### **Cost:** 15 Character Points<br>**Prerequisite:** Bardic Performance and 4 Other Bard Talents
 *Your Bardic Performance can plant the most subtle of compulsions in the minds of those who listen to you.*
 
-You can use two Actions to make a Charisma (Performance) check against a target's Wisdom defense. If successful, you speak a statement up to two sentences directing a course of action, and the target will follow it to the best of their ability. It must be worded in a way that sounds reasonable for the target. The directed action must be able to be completed within the next 8 hours. A trigger can also be given to the target as well, such as giving away all of their money if someone asks for charity. Creatures immune to the [Charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/) condition are immune to this effect.
+You can use two actions to make a Performance check against a target's Wisdom defense. If successful, you speak a statement up to two sentences directing a course of action, and the target will follow it to the best of their ability. It must be worded in a way that sounds reasonable for the target. The directed action must be able to be completed within the next 8 hours. A trigger can also be given to the target as well, such as giving away all of their money if someone asks for charity. Creatures immune to the [Charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/) condition are immune to this effect.
 
 ### Dirge of Doom
 

--- a/Talents/Bard/index.md
+++ b/Talents/Bard/index.md
@@ -30,23 +30,41 @@ Untold wonders and secrets exist for those skillful enough to discover them. Thr
 
 <div style="margin-top:-10px;"></div>
 
-#### **Cost:** 5 Character Points
+#### **Cost:** 5 Character Points<br>**Actions:** 1
+You are trained to use the [Performance](https://stormchaserroleplaying.com/stormchaserRPG/Skills/Performance/) skill to manipulate those around you.
+
+Starting a bardic performance is an action and must be maintained each round as an action. Changing a bardic performance from one effect to another requires you to stop the previous performance and start a new one as an action. A bardic performance cannot be disrupted, but it ends immediately if the bard is killed, paralysed, stunned, knocked unconscious, or otherwise prevented from taking an action to maintain it each round.
+
+Each bardic performance has audible components, visual components, or both.
+
+If a bardic performance has audible components, the targets must be able to hear the bard for the performance to have any effect, and many such performances are language dependent (as noted in the description). A deaf bard has a 20% chance to fail when attempting to use a bardic performance with an audible component. If he fails this check, the attempt still counts against his daily limit. Deaf creatures are immune to bardic performances with audible components.
+
+If a bardic performance has a visual component, the targets must have line of sight to the bard for the performance to have any effect. A blind bard has a 50% chance to fail when attempting to use a bardic performance with a visual component. If he fails this check, the attempt still counts against his daily limit. Blind creatures are immune to bardic performances with visual components.
+
+You can use this feature a number of times equal to your Charisma modifier. You regain any expended uses when you finish a short or long rest.
 
 #### Bardic Inspiration
 *You can inspire others through stirring words or music.*
 
-To do so, you use an action on your turn to choose one creature other than yourself within 60 feet of you who can hear you. That creature gains one Bardic Inspiration die, a d20.
+To do so, choose one creature other than yourself within 60 feet of you who can hear you. That creature gains one Bardic Inspiration die, a d20.
 
-Once within the next 10 minutes, the creature can roll the die as an instance of advantage on one ability check, attack roll, or defence check it makes. The creature can wait until after it rolls the original die before deciding to use the Bardic Inspiration die, but must decide before the DM says whether the roll succeeds or fails. Once the Bardic Inspiration die is rolled, it is lost. A creature can have only one Bardic Inspiration die at a time.
-
-You can use this feature a number of times equal to your Charisma modifier (a minimum of once). You regain any expended uses when you finish a short or long rest.
+Once within the next 10 minutes, the creature can roll the die as +1d on one ability check, attack roll, or defence check it makes. The creature can wait until after it rolls the original die before deciding to use the Bardic Inspiration die, but must decide before the GM says whether the roll succeeds or fails. Once the Bardic Inspiration die is rolled, it is lost. A creature can have only one Bardic Inspiration die at a time.
 
 Additionally, you can use soothing music or oration to help revitalise your wounded allies during a short rest. At the end of the short rest, you and any friendly creatures who can hear your performance regain stamina equal to the result of one Hit Die plus their Constitution modifier.
 
 #### Countersong
 *You gain the ability to use musical notes or words of power to disrupt mind-influencing effects.*
 
-As an action, you can start a performance that lasts until the end of your next turn. During that time, you and any friendly creatures within 30 feet of you have +1d to your defences vs being [frightened](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/) or [charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/). A creature must be able to hear you to gain this benefit. The performance ends early if you are [incapacitated](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Incapacitated/) or silenced or if you voluntarily end it (no action required).
+You can start a performance that lasts until the end of your next turn. During that time, you and any friendly creatures within 30 feet of you have +1d to your defences vs being [frightened](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/) or [charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/). A creature must be able to hear you to gain this benefit. The performance ends early if you are [incapacitated](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Incapacitated/) or silenced or if you voluntarily end it (no action required).
+
+#### Fascinate
+*You use your performance to cause one or more creatures to become fascinated with you.*
+
+Each creature to be fascinated must be within 90 feet, able to see and hear you, and capable of paying attention to you. You bard must also be able to see the creatures affected. The distraction of a nearby combat or other dangers prevents the ability from working. You can target a number of creature's equal to your Charisma modifier with this ability.
+
+Make a [Performance](https://stormchaserroleplaying.com/stormchaserRPG/Skills/Performance/) check vs the Wisdom defence of each creatrue targetted. On a miss, you cannot attempt to fascinate that creature again for 24 hours. On a hit, the creature sits quietly and observes the performance for as long as you continue to maintain it. While fascinated, a target has –1d penalty on skill checks, such as Perception checks.
+
+Any potential threat to the target allows the target to make a Wisdom defence check against the effect. Any obvious threat, such as someone drawing a weapon, casting a spell, or aiming a weapon at the target, automatically breaks the effect. Fascinate is a mind-affecting charm and relies on audible and visual components in order to function.
 
 ### Jack of All Trades
 
@@ -69,27 +87,27 @@ Once per round, you may choose a target within 60 feet that you can see. The tar
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 15 Character Points<br>**Prerequisite:** Bardic Performance and 4 Other Bard Talents
-*Your Bardic Performance can plant the most subtle of compulsions in the minds of those who listen to you.*
+You can make a [Performance](https://stormchaserroleplaying.com/stormchaserRPG/Skills/Performance/) check vs the target's Wisdom defense to make a suggestion (as per the spell) to a creature that you have already fascinated (see above).
 
-You can use two actions to make a Performance check against a target's Wisdom defense. If successful, you speak a statement up to two sentences directing a course of action, and the target will follow it to the best of their ability. It must be worded in a way that sounds reasonable for the target. The directed action must be able to be completed within the next 8 hours. A trigger can also be given to the target as well, such as giving away all of their money if someone asks for charity. Creatures immune to the [Charmed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Charmed/) condition are immune to this effect.
+Using this ability does not disrupt the fascinate effect. However, it does require an action to activate (in addition to the action to continue the fascinate effect). A bard can use this ability more than once against an individual creature during an individual performance. This ability affects only a single creature (but see mass suggestion, below). Suggestion is a mind-affecting, language-dependent charm ability and relies on audible components.
 
 ### Dirge of Doom
 
 <div style="margin-top:-10px;"></div>
 
-#### **Cost:** 20 Character Points<br>**Prerequisite:** Suggestion and 5 Other Bard Talents
-*Your words cut deep into the hearts of the bold, exposing a gap in the armour of their courage.*
-
-When you use your Bardic Performance, you can spend 2 Actions to choose a number of targets up to your Charisma modifier within 30 feet. Make a Charisma (Performance) check against the Wisdom defense of each target. If successful, the target is [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/). Each time you use this Performance against the same target, your Charisma (Performance) check receives -1d.
+#### **Cost:** 20 Character Points<br>**Prerequisite:** Suggestion and 5 Other Bard Talents<br>**Actions:** 1
+You can use your performance to foster a sense of growing dread in his enemies, causing them to take become [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/). To be affected, an enemy must be within 30 feet and able to see and hear your performance. The effect persists for as long as the enemy is within 30 feet and you continue the performance. The performance cannot cause a creature to become frightened or panicked, even if the targets are already [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/) from another effect. Dirge of doom is a mind-affecting fear effect that relies on audible and visual components.
 
 ### Inspire Greatness
 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 25 Character Points<br>**Prerequisite:** Bardic Performance and 6 Other Bard Talents
-*Through your force of will, heroes rise to deeds worthy of legend.*
+You can use your performance to inspire greatness in a number of willing creatures (including yourself) equal to your Charisma modifier, granting extra fighting capability.
 
-Choose an ally within 30 feet. They receive 2 Recovery Dice of Stamina, the larger of the two rolls as temporary Stamina, +1d to attack rolls, and +1d to Charisma defense for a number of rounds equal to your Charisma modifier. 
+To inspire greatness, all of the targets must be able to see and hear you. A creature inspired with greatness gains 2d10 temporary stamina (apply the target’s Constitution modifier to these bonus temporary hit points), +1d on attack rolls, and +1d to Constitution defence.
+
+Inspire greatness is a mind-affecting ability that relies on audible and visual components.
 
 ### Peerless Skill
 
@@ -103,45 +121,47 @@ When you make a skill check, you can spend a use of your bardic inspiration die 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 30 Character Points<br>**Prerequisite:** Bardic Performance and 8 Other Bard Talents
-*When things seem grim and your allies turn to despair, you offer a rallying cry to bolster their hearts.*
+You can use your performance to create an effect equivalent to a 3rd-level Heal spell, using the bard’s Charisma as the spellcasting ability. In addition, this performance removes the Fatigued, Sickened, and [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/) conditions from all those affected.
 
-You can spend 1 Action per round (up to six rounds) to give 2 Recovery Dice and remove 1 condition from a target of your choice. The condition removed must be [Dazed](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Dazed/), [Frightened](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/), [Panicked](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Panicked/), [Shaken](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Shaken/), or [Stunned](https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Stunned/). Only one target can be affected each time you use this Performance.
+Using this ability requires 4 rounds of continuous performance and the targets must be able to see and hear you throughout the performance.
+
+Soothing performance relies on audible and visual components.
 
 ### Frightening Tune
 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 65 Character Points<br>**Prerequisite:** Dirge of Doom and 10 Other Bard Talents
-*"Ask not for whom the bell tolls..."*
+*You can use your performance to cause fear in your enemies.*
 
-Spend 2 Actions, then 1 Action per round afterward until you choose to end this Performance. All hostile targets within 30 feet of you become [Frightened]((https://stormchaserroleplaying.com/stormchaserRPG/Conditions/Frightened/) of you until they succeed a Wisdom check against your Charisma Defense. Targets who have been affected by your Dirge of Doom Performance receive -1d to their check to end the effect. If a target moves far enough away that they cannot hear you, the effect ends until they are close enough to hear you again.
+To be affected, an enemy must be able to hear the bard perform and be within 30 feet. Make a [Performance](https://stormchaserroleplaying.com/stormchaserRPG/Skills/Performance/) check vs the Wisdom defense of each enemy within range. On a miss, the creature is immune to this ability for 24 hours. On a hit, the target becomes frightened and flees for as long as it can hear your performance.
+
+Frightening tune relies on audible components.
 
 ### Inspire Heroics
 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 40 Character Points<br>**Prerequisite:** Inspire Greatness and 11 Other Bard Talents
-*"I once saw a man thrown across the room by a rampaging golem. He stood up, wiped the blood from his mouth, and said, "I can do this all day."*
+Your can inspire tremendous heroism in a number of willing creatures (including yourself) within 30 feet equal to your Charisma modifier. To inspire heroics, all of the targets must be able to see and hear you. Inspired creatures gain a +1d morale bonus to their defences. The effect lasts for as long as the targets are able to witness the performance.
 
-Spend 3 Actions, then 1 Action per round afterward until you choose to end this Performance. A number of targets within 60 feet up to your Charisma Modifier receive +1d to all defenses every round while you maintain this Performance.
+Inspire heroics is a mind-affecting ability that relies on audible and visual components.
 
 ### Mass Suggestion
 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 80 Character Points<br>**Prerequisite:** Suggestion and 12 Other Bard Talents
-*Your sword will end my life, but my words moved your people to end your reign.*
-
-When you use your Suggestion Performance, you can now influence up to 12 targets within 60 feet who can hear you.
+This ability functions just like suggestion, but allows you to make a suggestion simultaneously to any number of creatures that you have already fascinated. Mass suggestion is a mind-affecting, language dependent charm ability that relies on audible components.
 
 ### Deadly Performance
 
 <div style="margin-top:-10px;"></div>
 
 #### **Cost:** 50 Character Points<br>**Prerequisite:** Bardic Performance and 13 Other Bard Talents
-*When she danced, the world seemed to pause to become her audience. When she finished, all the world's gaze stayed fixed to her, dead and cold.*
+You an use your performance to cause one enemy to die from joy or sorrow. To be affected, the target must be able to see and hear you perform for 1 full round and be within 30 feet. ake a [Performance](https://stormchaserroleplaying.com/stormchaserRPG/Skills/Performance/) check vs the Wisdom defense of each enemy within range. On a miss, the effect is negated, the target is staggered for 1d4 rounds, and you cannot use deadly performance on that creature again for 24 hours. On a hit, it dies.
 
-Spend 3 Actions. Make a Charisma (Performance) check against the Wisdom defense of a target within 30 feet that can hear and see you. On a success, the target takes 7d8+30 profane damage. On a failure, the target is Dazed for a number of rounds equal to your Charisma Modifier. Invoking this Performance calls forth hungry, angry spirits from a plane devoid of life. If a Bard uses this Performance more than once per day, they must make a DC 17 Constituion check. On a failure, the Performance acts normally, but they user also suffers the largest rolled damage die, plus their Charisma modifier, profane damage.
+Deadly performance is a mind-effecting death effect that relies on audible and visual components.
 
 ### Virtuoso
 


### PR DESCRIPTION
- All Bardic Performances should share the same pool of charges - including Bardic Inspiration. Being a SR recovery, and the average Bard will typically have +4 or +5 CHA Mod (maybe +2 or +3 for dip), it can still be used without concern over running out of charges for a long period of time. I wanted to put this up for consideration/discussion before changing the base Bardic Performance talent to specify this.

- Dirge of Doom: Shaken is a strong condition to inflict, and a second application upgrades to Frightened (not sure if they have to still be Shaken, though). Thinking repeated uses against the same target should be harder to stick, otherwise Bards could make half a battle just run away.